### PR TITLE
🐛 Fix finalize of creating a new project

### DIFF
--- a/lib/views/NewProjectView.js
+++ b/lib/views/NewProjectView.js
@@ -15,11 +15,14 @@ export default class NewProjectView extends BaseView {
     const onConfirm = cmp => event => {
       console.log(cmp.path)
       console.log(cmp.kernel)
-      // TODO: handle these callbacks more generically
       createNewProject(new MiddlewareCallbackHelper({
         finalize: d => {
+					if(d.method != 'project-report') {
+						return
+					}
           proj = d.data.project
-          atom.notifications.addSuccess(`Created PROS project for ${proj.target} at ${proj.location}`)
+					lines = d.human.split('\n')
+          atom.notifications.addSuccess(lines[0], {detail: lines.slice(1).join('\n')})
           atom.project.addPath(proj.location)
           glob(`${proj.location}/src/opcontrol.*`, function (err, files) {
             if(files.length > 0) {


### PR DESCRIPTION
Summary:
Fixed finalize of creating a new project so that it only renders that finalize message on the project-report (not whenever a template is applied). Also adjusted the notification to use the PROS CLI's human readable output, rather than generating our own message

Test Plan:
- Verified behavior worked as intended in PROS Editor x64