### PR TITLE
📇 Add templates for issues and PRs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at pros_development@cs.purdue.edu. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,11 +1,28 @@
 # Contributing to PROS
 
-:+1: :steam_locomotive: Thanks for taking the time to contribute :steam_locomotive: :+1:
+:tada: :+1: :steam_locomotive: Thanks for taking the time to contribute! :steam_locomotive: :+1: :tada:
 
 **Did you find a bug?**
-- **Ensure the bug wasn't already reported** by searching GitHub [issues](https://github.com/purduesigbots/pros-atom3/issues)
-- If you're unable to find an issue, [open](https://github.com/purduesigbots/pros-atom3/issues/new) one.
+- **Before opening an issue, make sure you are in the right repository!**
+  purduesigbots maintains four repositories related to PROS:
+  - [purduesigbots/pros](https://github.com/purduesigbots/pros): the repository containing the source code for the kernel the user-facing API. Issues should be opened here if they affect the code you write (e.g., "I would like to be able to do X with PROS," or "when I call <PROS function> X doesn't work as I expect")
+  - [purduesigbots/pros-cli](https://github.com/purduesigbots/pros-cli): the repository containing the source code for the command line interface (CLI). Issues should be opened here if they concern the PROS CLI (e.g., problems with commands like `pros make`), as well as project creation and management.
+  - [purduesigbots/pros-atom](https://github.com/purduesigbots/pros-atom): the repository containing the source code for the Atom package. Issues should be opened here if they concern the coding experience within Atom (e.g., "there is no button to do X," or "the linter is spamming my interface with errors").
+  - [purduesigbots/pros-docs](https://github.com/purduesigbots/pros-docs): the repository containing the source code for [our documentation website](https://pros.cs.purdue.edu). Issues should be opened here if they concern available documentation (e.g., "there is not guide on using <PROS feature>," or "the documentation says to do X, but only Y works")
+- **Verify the bug lies in PROS.** We receive quite a few reports that are due to bugs in user code, not the kernel.
+- Ensure the bug wasn't already reported by searching GitHub [issues](https://github.com/purduesigbots/pros/issues)
+- If you're unable to find an issue, [open](https://github.com/purduesigbots/pros/issues/new) a new one.
 
 **Did you patch a bug or add a new feature?**
-- Open a pull request
-- Ensure the pull request description clearly describes the problem and solution. If there's an issue number, include it so it can be referenced.
+1. [Fork](https://github.com/purduesigbots/pros-atom/fork) and clone the repository
+2. Create a new branch: `git checkout -b my-branch-name`
+3. Make your changes
+4. Push to your fork and submit a pull request.
+5. Wait for your pull request to be reviewed.
+
+Here are a few tips that can help expedite your pull request being accepted:
+- Follow existing code's style.
+- Document why you made the changes you did
+- Keep your change as focused as possible. If you have multiple independent changes, make a pull request for each.
+- If you did some testing, describe your procedure and results.
+- If you're fixing an issue, reference it by number

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to PROS
+
+:+1: :steam_locomotive: Thanks for taking the time to contribute :steam_locomotive: :+1:
+
+**Did you find a bug?**
+- **Ensure the bug wasn't already reported** by searching GitHub [issues](https://github.com/purduesigbots/pros-atom3/issues)
+- If you're unable to find an issue, [open](https://github.com/purduesigbots/pros-atom3/issues/new) one.
+
+**Did you patch a bug or add a new feature?**
+- Open a pull request
+- Ensure the pull request description clearly describes the problem and solution. If there's an issue number, include it so it can be referenced.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+### Expected Behavior:
+
+[what did you expect to happen?]
+
+### Actual Behavior:
+
+[what actually happened?]
+
+### Steps to reproduce:
+
+[can you make this happen again? if so, explain how here]
+
+### System information:
+- Operating System (e.g. Windows, OS X, Ubuntu):
+- Atom Version:
+- Plugin Version (PROS version):
+
+### Additional Information
+
+[is there any additional information about this issue?]
+
+### Screenshots
+
+[screenshots are always helpful]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+### Summary
+
+[Enter a summary of the proposed changes here]
+
+### Test Plan
+
+- [ ] list of things that can be tested to verify PR
+- [ ] ...
+- [ ] profit

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,7 @@
 - [ ] list of things that can be tested to verify PR
 - [ ] ...
 - [ ] profit
+
+#### References
+
+[include references to other pull requests or issues here]


### PR DESCRIPTION
<sup>is it ironic that the template doesn't apply to its own PR?</sup>

### Summary

Adding templates for issues and PRs on GitHub. Also add contribution guidelines (stolen from purduesigbots/pros-atom)

- Add `.github/PULL_REQUEST_TEMPLATE.md`
- Add `.github/ISSUE_TEMPLATE.md`
- Add `.github/CONTRIBUTING.md`

### Test Plan

- [ ] editing/revision