### PR TITLE
Fix initial value for KernelPickerComponent, move PROS menu to root menu

### DIFF
--- a/lib/components/pros/FolderPickerComponent.js
+++ b/lib/components/pros/FolderPickerComponent.js
@@ -8,11 +8,10 @@ export default class FolderPickerComponent {
   constructor(props) {
     this.props = props
 
-    this.onPickDir = cmp => event => {
+    this.onPickDir = () => event => {
       atom.pickFolder(paths => {
         if (paths && paths[0]) {
-          this.props.onChanged(paths[0])
-          this.update({dir: paths[0]})
+          this._updateDir(paths[0])
         }
       })
     }
@@ -21,16 +20,21 @@ export default class FolderPickerComponent {
 
     this.refs.editor.setPlaceholderText('Enter a path')
     this.refs.editor.onDidStopChanging((event) => {
-      this.props.onChanged(this.refs.editor.getText())
-      this.update({})
+      this._updateDir()
     })
   }
-  update(props) {
-    if (props.dir) {
-      this.refs.editor.setText(props.dir)
+
+  _updateDir(dir) {
+    this.props.onChanged(this.refs.editor.getText())
+    if(dir) {
+      this.refs.editor.setText(dir)
     }
+  }
+
+  update(props) {
     return etch.update(this)
   }
+
   render() {
     return (
       <div class='file-picker-container'>

--- a/lib/components/pros/FolderPickerComponent.js
+++ b/lib/components/pros/FolderPickerComponent.js
@@ -4,15 +4,14 @@
 import etch from 'etch'
 import { TextEditor } from 'atom'
 
-export default class FodlerPickerComponent {
+export default class FolderPickerComponent {
   constructor(props) {
     this.props = props
 
     this.onPickDir = cmp => event => {
-      const { onChanged } = cmp.props
       atom.pickFolder(paths => {
         if (paths && paths[0]) {
-          onChanged(paths[0])
+          this.props.onChanged(paths[0])
           this.update({dir: paths[0]})
         }
       })
@@ -21,9 +20,13 @@ export default class FodlerPickerComponent {
     etch.initialize(this)
 
     this.refs.editor.setPlaceholderText('Enter a path')
+    this.refs.editor.onDidStopChanging((event) => {
+      this.props.onChanged(this.refs.editor.getText())
+      this.update({})
+    })
   }
   update(props) {
-    if (props.dir && this.dir !== props.dir) {
+    if (props.dir) {
       this.refs.editor.setText(props.dir)
     }
     return etch.update(this)
@@ -33,7 +36,7 @@ export default class FodlerPickerComponent {
       <div class='file-picker-container'>
         <h4>Choose a directory</h4>
         <div class='file-picker' style='display: flex; flex-direction: row-reverse'>
-          <button class='btn btn-default' onclick={this.onPickDir(this)}>
+          <button class='btn btn-default' onclick={this.onPickDir()}>
             <span class='icon icon-ellipsis'></span>
           </button>
           <div class='editor-container' style='flex-grow: 3'>

--- a/lib/components/pros/FolderPickerComponent.js
+++ b/lib/components/pros/FolderPickerComponent.js
@@ -8,7 +8,7 @@ export default class FolderPickerComponent {
   constructor(props) {
     this.props = props
 
-    this.onPickDir = () => event => {
+    this.onPickDir = event => {
       atom.pickFolder(paths => {
         if (paths && paths[0]) {
           this._updateDir(paths[0])
@@ -40,7 +40,7 @@ export default class FolderPickerComponent {
       <div class='file-picker-container'>
         <h4>Choose a directory</h4>
         <div class='file-picker' style='display: flex; flex-direction: row-reverse'>
-          <button class='btn btn-default' onclick={this.onPickDir()}>
+          <button class='btn btn-default' onclick={this.onPickDir}>
             <span class='icon icon-ellipsis'></span>
           </button>
           <div class='editor-container' style='flex-grow: 3'>

--- a/lib/components/pros/KernelPickerComponent.js
+++ b/lib/components/pros/KernelPickerComponent.js
@@ -14,11 +14,11 @@ export default class KernelPickerComponent {
     this.kList = [this.latestOption]
     // set up callback for updating this value
     this.handleChange = event => this.props.onChanged(event.target.value)
+    // set initial value
+    this.selectedKernel = 'latest'
 
     etch.initialize(this)
 
-    // set initial value
-    this.props.onChanged(this.latestOption.domNode.value)
     listTemplates(new MiddlewareCallbackHelper({
       finalize: finalData => this.dispList(finalData)
     })).catch(e => console.error(e))

--- a/menus/pros-atom3.json
+++ b/menus/pros-atom3.json
@@ -1,20 +1,15 @@
 {
   "menu": [
     {
-      "label": "Packages",
+      "label": "PROS",
       "submenu": [
         {
-          "label": "PROS",
-          "submenu": [
-            {
-              "label": "New Project",
-              "command": "pros:new-project"
-            },
-            {
-              "label": "Upgrade Project",
-              "command": "pros:upgrade-project"
-            }
-          ]
+          "label": "New Project",
+          "command": "pros:new-project"
+        },
+        {
+          "label": "Upgrade Project",
+          "command": "pros:upgrade-project"
         }
       ]
     }


### PR DESCRIPTION
### Summary

- Fix initial value for KernelPickerComponent
- Move PROS menu to root menu
- FolderPickerComponent now respects a path manually typed/pasted into the text editor.

### Test Plan

- [X] New project dialog immediate shows "latest" as selected option, not waiting for CLI to come back with the list of kernels
- [X] PROS menu is now at root level, more accessible for users. We're a full blown IDE usually installed with PROS Editor, so we can have our own menu.

#### References

N/A
