### PR TITLE
♻️ disallow project creation with no path specified

### DIFF
--- a/lib/components/buttons/GenericButtonComponent.js
+++ b/lib/components/buttons/GenericButtonComponent.js
@@ -8,7 +8,8 @@ export default class GenericButtonComponent {
     this.props = props
     etch.initialize(this)
   }
-  update() {
+  update(props) {
+    this.props = props
     return etch.update(this)
   }
   render() {
@@ -17,10 +18,11 @@ export default class GenericButtonComponent {
       isDefault,
       iconClass,
       onclick,
-      text
+      text,
+      disabled
     } = this.props
     const btnClass = `${isPrimary ? 'btn btn-primary' : isDefault ? 'btn btn-default' : 'btn'} ${iconClass || ''}`
-    return <button class={btnClass} onclick={onclick}>{text || ''}</button>
+    return <button class={btnClass} onclick={onclick} disabled={disabled}>{text || ''}</button>
   }
   destroy() {
     return etch.destroy(this)

--- a/lib/components/buttons/YesNoButtonComponent.js
+++ b/lib/components/buttons/YesNoButtonComponent.js
@@ -11,21 +11,24 @@ export default class YesNoButtonComponent {
 
     etch.initialize(this)
   }
-  update() {
+  update(props) {
+    this.props = props
     return etch.update(this)
   }
   render() {
     const {
       yes,
       onclick,
-      confirmText
+      confirmText,
+      disabled
     } = this.props
     return (
       <GenericButtonComponent
         isPrimary={yes}
         iconClass={yes ? 'icon icon-rocket' : ''}
         onclick={onclick}
-        text={yes ? (confirmText || 'OK') : 'Cancel'} />
+        text={yes ? (confirmText || 'OK') : 'Cancel'}
+        disabled={disabled} />
     )
   }
   destroy() {

--- a/lib/components/modals/GenericModalComponent.js
+++ b/lib/components/modals/GenericModalComponent.js
@@ -20,6 +20,9 @@ export default class GenericModalComponent {
     if (props.dropdownElem) {
       this.props.dropdownElem = props.dropdownElem
     }
+    if (props.buttons) {
+      this.props.buttons = props.buttons
+    }
     return etch.update(this)
   }
   render() {

--- a/lib/components/modals/NewProjectComponent.js
+++ b/lib/components/modals/NewProjectComponent.js
@@ -12,15 +12,14 @@ export default class NewProjectComponent {
     this.props = props
 
     this.path = ''
-    this.setPath = path => this.path = path
+    this.setPath = path => {
+      this.path = path
+      this.update()
+    }
     this.setKernel = kernel => this.kernel = kernel
 
     this.inputElem = <FolderPickerComponent onChanged={this.setPath} />
     this.dropdown = <KernelPickerComponent onChanged={this.setKernel} />
-    this.buttons = [
-      <YesNoButtonComponent yes onclick={this.props.confirm(this)} confirmText='Create Project' />,
-      <YesNoButtonComponent onclick={this.props.cancel(this)} />
-    ]
 
     etch.initialize(this)
   }
@@ -28,6 +27,10 @@ export default class NewProjectComponent {
     return etch.update(this)
   }
   render() {
+    this.buttons = [
+      <YesNoButtonComponent yes onclick={this.props.confirm(this)} disabled={this.path === ''} confirmText='Create Project' />,
+      <YesNoButtonComponent onclick={this.props.cancel(this)} />
+    ]
     return (
       <GenericModalComponent
         modalClass='new-project-modal'

--- a/lib/views/NewProjectView.js
+++ b/lib/views/NewProjectView.js
@@ -13,8 +13,6 @@ import { MiddlewareCallbackHelper } from '../middleware-linkage'
 export default class NewProjectView extends BaseView {
   constructor() {
     const onConfirm = cmp => event => {
-      console.log(cmp.path)
-      console.log(cmp.kernel)
       createNewProject(new MiddlewareCallbackHelper({
         finalize: d => {
           if(d.method != 'project-report') {
@@ -35,7 +33,6 @@ export default class NewProjectView extends BaseView {
       this.cancel()
     }
     const onCancel = cmp => event => {
-      console.log('cancelled!')
       this.cancel()
     }
 


### PR DESCRIPTION
### Summary

Sets the primary "create" button to `disabled` while the path has not been set

### Test Plan

- [X] button is disabled until user enters text into mini editor
- [x] button is disabled until user selects a folder using dialog
- [x] button becomes disabled again when text is deleted from mini editor

#### References
closes T570