### PR TITLE
🚸 add default path when creating new project

### DIFF
--- a/lib/components/modals/NewProjectComponent.js
+++ b/lib/components/modals/NewProjectComponent.js
@@ -19,15 +19,37 @@ export default class NewProjectComponent {
       this.update()
     }
     this.setKernel = kernel => this.kernel = kernel
+
+    // default path logic:
+    // 1. path = os.homedir()
+    // 2. if there is an active editor, path = editor.getDirectoryPath()
+    // 2.1 if there are also projects open, find project directory associated
+    //      with the currently active file and set path to parent directory of
+    //      that directory
+    // 2.2 if there are no projects open or the active file isn't part of one,
+    //      fallthrough case is (2)
+    // 3. if there is no active editor (in (2)), use first project's parent dir
+    // 4. if after 1-3 the default path is still undefined (e.g. default buffer
+    //      is open), set to os.homedir
+    // 5. if all else fails, fallthrough case is (1)
     let defaultPath = os.homedir()
     const activeEditor = atom.workspace.getActiveTextEditor()
     if (activeEditor) {
-      defaultPath = path.dirname(activeEditor.getPath())
+      defaultPath = activeEditor.getDirectoryPath()
+      if (atom.project.rootDirectories.length) {
+        for (let dir of atom.project.rootDirectories) {
+          if (dir.isPathPrefixOf(dir.realPath, activeEditor.getPath())) {
+            defaultPath = path.dirname(dir.realPath)
+          }
+        }
+      }
     } else {
       if (atom.workspace.project.getPaths().length) {
         defaultPath = path.dirname(atom.workspace.project.getPaths()[0])
-      } // fallthrough: os.homedir()
+      }
     }
+    if (defaultPath === undefined) defaultPath = os.homedir()
+
     this.inputElem = <FolderPickerComponent defaultPath={defaultPath} onChanged={this.setPath} />
     this.dropdown = <KernelPickerComponent onChanged={this.setKernel} />
 

--- a/lib/components/modals/NewProjectComponent.js
+++ b/lib/components/modals/NewProjectComponent.js
@@ -2,6 +2,8 @@
 /** @jsx etch.dom */
 
 import etch from 'etch'
+import os from 'os'
+import path from 'path'
 
 import GenericModalComponent from './GenericModalComponent.js'
 import { YesNoButtonComponent } from '../buttons'
@@ -17,8 +19,16 @@ export default class NewProjectComponent {
       this.update()
     }
     this.setKernel = kernel => this.kernel = kernel
-
-    this.inputElem = <FolderPickerComponent onChanged={this.setPath} />
+    let defaultPath = os.homedir()
+    const activeEditor = atom.workspace.getActiveTextEditor()
+    if (activeEditor) {
+      defaultPath = path.dirname(activeEditor.getPath())
+    } else {
+      if (atom.workspace.project.getPaths().length) {
+        defaultPath = path.dirname(atom.workspace.project.getPaths()[0])
+      } // fallthrough: os.homedir()
+    }
+    this.inputElem = <FolderPickerComponent defaultPath={defaultPath} onChanged={this.setPath} />
     this.dropdown = <KernelPickerComponent onChanged={this.setKernel} />
 
     etch.initialize(this)

--- a/lib/components/pros/FolderPickerComponent.js
+++ b/lib/components/pros/FolderPickerComponent.js
@@ -22,6 +22,10 @@ export default class FolderPickerComponent {
     this.refs.editor.onDidStopChanging((event) => {
       this._updateDir()
     })
+    if (this.props.defaultPath) {
+      this.refs.editor.setText(this.props.defaultPath)
+      this._updateDir()
+    }
   }
 
   _updateDir(dir) {


### PR DESCRIPTION
### Summary

set default path when creating new project, according to the following logic:

1. `path = os.homedir()`
2. if there is an active editor, `path = editor.getDirectoryPath()`
2.1 if there are also projects open, find project directory associated with the currently active file and set path to parent directory of that directory
2.2 if there are no projects open or the active file isn't part of one, fallthrough case is (2)
3. if there is no active editor (in (2)), use first project's parent dir
4. if after 1-3 the default path is `undefined` (e.g. default buffer is open), set to `os.homedir`
5. if all else fails, fallthrough case is (1)

### Test Plan

- [X] when file is open from a project, default path is parent directory of project root
- [X] when no file is open, but there are projects, default path is parent directory of first project root in list
- [X] when no files or projects are open, default path is `os.homedir`
- [X] when the default (untitled) file is open (e.g. when making a new window), default path is `os.homedir`

#### References
closes T569
