### PR TITLE
 👽 build compile_commands after project creation

### DIFF
--- a/lib/components/modals/NewProjectComponent.js
+++ b/lib/components/modals/NewProjectComponent.js
@@ -19,15 +19,37 @@ export default class NewProjectComponent {
       this.update()
     }
     this.setKernel = kernel => this.kernel = kernel
+
+    // default path logic:
+    // 1. path = os.homedir()
+    // 2. if there is an active editor, path = editor.getDirectoryPath()
+    // 2.1 if there are also projects open, find project directory associated
+    //      with the currently active file and set path to parent directory of
+    //      that directory
+    // 2.2 if there are no projects open or the active file isn't part of one,
+    //      fallthrough case is (2)
+    // 3. if there is no active editor (in (2)), use first project's parent dir
+    // 4. if after 1-3 the default path is still undefined (e.g. default buffer
+    //      is open), set to os.homedir
+    // 5. if all else fails, fallthrough case is (1)
     let defaultPath = os.homedir()
     const activeEditor = atom.workspace.getActiveTextEditor()
     if (activeEditor) {
-      defaultPath = path.dirname(activeEditor.getPath())
+      defaultPath = activeEditor.getDirectoryPath()
+      if (atom.project.rootDirectories.length) {
+        for (let dir of atom.project.rootDirectories) {
+          if (dir.isPathPrefixOf(dir.realPath, activeEditor.getPath())) {
+            defaultPath = path.dirname(dir.realPath)
+          }
+        }
+      }
     } else {
       if (atom.workspace.project.getPaths().length) {
         defaultPath = path.dirname(atom.workspace.project.getPaths()[0])
-      } // fallthrough: os.homedir()
+      }
     }
+    if (defaultPath === undefined) defaultPath = os.homedir()
+
     this.inputElem = <FolderPickerComponent defaultPath={defaultPath} onChanged={this.setPath} />
     this.dropdown = <KernelPickerComponent onChanged={this.setKernel} />
 

--- a/lib/components/modals/NewProjectComponent.js
+++ b/lib/components/modals/NewProjectComponent.js
@@ -2,6 +2,8 @@
 /** @jsx etch.dom */
 
 import etch from 'etch'
+import os from 'os'
+import path from 'path'
 
 import GenericModalComponent from './GenericModalComponent.js'
 import { YesNoButtonComponent } from '../buttons'
@@ -17,8 +19,16 @@ export default class NewProjectComponent {
       this.update()
     }
     this.setKernel = kernel => this.kernel = kernel
-
-    this.inputElem = <FolderPickerComponent onChanged={this.setPath} />
+    let defaultPath = os.homedir()
+    const activeEditor = atom.workspace.getActiveTextEditor()
+    if (activeEditor) {
+      defaultPath = path.dirname(activeEditor.getPath())
+    } else {
+      if (atom.workspace.project.getPaths().length) {
+        defaultPath = path.dirname(atom.workspace.project.getPaths()[0])
+      } // fallthrough: os.homedir()
+    }
+    this.inputElem = <FolderPickerComponent defaultPath={defaultPath} onChanged={this.setPath} />
     this.dropdown = <KernelPickerComponent onChanged={this.setKernel} />
 
     etch.initialize(this)

--- a/lib/components/modals/NewProjectComponent.js
+++ b/lib/components/modals/NewProjectComponent.js
@@ -19,6 +19,8 @@ export default class NewProjectComponent {
       this.update()
     }
     this.setKernel = kernel => this.kernel = kernel
+    // TODO: properly handle target param
+    this.setTarget = target => this.target = target
 
     // default path logic:
     // 1. path = os.homedir()

--- a/lib/components/pros/FolderPickerComponent.js
+++ b/lib/components/pros/FolderPickerComponent.js
@@ -22,6 +22,10 @@ export default class FolderPickerComponent {
     this.refs.editor.onDidStopChanging((event) => {
       this._updateDir()
     })
+    if (this.props.defaultPath) {
+      this.refs.editor.setText(this.props.defaultPath)
+      this._updateDir()
+    }
   }
 
   _updateDir(dir) {

--- a/lib/components/pros/KernelPickerComponent.js
+++ b/lib/components/pros/KernelPickerComponent.js
@@ -21,7 +21,7 @@ export default class KernelPickerComponent {
 
     listTemplates(new MiddlewareCallbackHelper({
       finalize: finalData => this.dispList(finalData)
-    })).catch(e => console.error(e))
+    }), 'kernel').catch(e => console.error(e))
   }
   dispList(d) {
     this.kList = d.data.map(e => {

--- a/lib/middleware-linkage/middlewareCallbackHelper.js
+++ b/lib/middleware-linkage/middlewareCallbackHelper.js
@@ -74,4 +74,4 @@ class MiddlewareCallbackHelper {
   }
 }
 
-export default { zCLIjs, MiddlewareCallbackHelper , getzCLIExecutable};
+export default { zCLIjs, MiddlewareCallbackHelper, getzCLIExecutable };

--- a/lib/middleware-linkage/notificationManager.js
+++ b/lib/middleware-linkage/notificationManager.js
@@ -1,5 +1,6 @@
 'use babel'
 
+import stripAnsi from 'strip-ansi'
 
 function createNewProgress() {
   let child = document.createElement('span')
@@ -32,7 +33,7 @@ export default class NotificationManager {
     let notification = this.get(data.notify_value)
     if(typeof notification === 'undefined') {
       this.notifications[data.notify_value] = {
-        'notification': atom.notifications.addInfo(data.text),
+        'notification': atom.notifications.addInfo(stripAnsi(data.text)),
         'detail': null
       }
       notification = this.notifications[data.notify_value]
@@ -48,7 +49,7 @@ export default class NotificationManager {
             child.style.whiteSpace = 'pre-wrap'
             notification['detail'].appendChild(child)
           }
-          child.textContent += data.text
+          child.textContent += stripAnsi(data.text)
         }
         if(data.type == 'notify/progress') {
           const newLabel = data.text + ' '

--- a/lib/views/NewProjectView.js
+++ b/lib/views/NewProjectView.js
@@ -8,29 +8,36 @@ import { createNewProject } from '@purduesigbots/pros-cli-middleware'
 
 import BaseView from './BaseView.js'
 import { NewProjectComponent } from '../components/modals'
-import { MiddlewareCallbackHelper } from '../middleware-linkage'
+import { zCLIjs, MiddlewareCallbackHelper } from '../middleware-linkage'
 
 export default class NewProjectView extends BaseView {
   constructor() {
     const onConfirm = cmp => event => {
-      createNewProject(new MiddlewareCallbackHelper({
+      let loc = ''
+      zCLIjs(createNewProject, {
         finalize: d => {
           if(d.method != 'project-report') {
             return
           }
           proj = d.data.project
           lines = d.human.split('\n')
-          atom.notifications.addSuccess(lines[0], {detail: lines.slice(1).join('\n')})
-          atom.project.addPath(proj.location)
-          glob(`${proj.location}/src/opcontrol.*`, function (err, files) {
+          atom.notifications.addSuccess(lines[0], {
+            detail: lines.slice(1).join('\n')
+          })
+          loc = proj.location
+        } // TODO: properly handle target param
+      }, cmp.path, cmp.kernel, 'v5', {cache: true}).then(code => {
+        if (code === 0) {
+          atom.project.addPath(loc)
+          glob(`${loc}/src/opcontrol.*`, (err, files) => {
             if(files.length > 0) {
               atom.workspace.open(files[0], {pending: true})
             }
           })
-        }}), // end of MiddlewareCallbackHelper
-        // TODO: properly handle target parameter
-        cmp.path, cmp.kernel, 'v5', {cache: true}
-      )
+        } else {
+          console.error(`build-compile-commands exited with error code ${code}`)
+        }
+      })
       this.cancel()
     }
     const onCancel = cmp => event => {

--- a/lib/views/NewProjectView.js
+++ b/lib/views/NewProjectView.js
@@ -27,6 +27,7 @@ export default class NewProjectView extends BaseView {
           loc = proj.location
         } // TODO: properly handle target param
       }, cmp.path, cmp.kernel, 'v5', {cache: true}).then(code => {
+        console.log(code);
         if (code === 0) {
           atom.project.addPath(loc)
           glob(`${loc}/src/opcontrol.*`, (err, files) => {
@@ -35,7 +36,7 @@ export default class NewProjectView extends BaseView {
             }
           })
         } else {
-          console.error(`build-compile-commands exited with error code ${code}`)
+          console.error(`failed to create and compile project (code ${code})`)
         }
       })
       this.cancel()

--- a/lib/views/NewProjectView.js
+++ b/lib/views/NewProjectView.js
@@ -28,7 +28,8 @@ export default class NewProjectView extends BaseView {
             }
           })
         }}), // end of MiddlewareCallbackHelper
-        cmp.path, cmp.kernel
+        // TODO: properly handle target parameter
+        cmp.path, cmp.kernel, 'v5', {cache: true}
       )
       this.cancel()
     }

--- a/lib/views/NewProjectView.js
+++ b/lib/views/NewProjectView.js
@@ -27,8 +27,9 @@ export default class NewProjectView extends BaseView {
           loc = proj.location
         } // TODO: properly handle target param
       }, cmp.path, cmp.kernel, 'v5', {cache: true}).then(code => {
-        console.log(code);
-        if (code === 0) {
+        // NOTE: createNewProject will definitely return -1 on error
+        //       (we want to open the project even if it didn't compile)
+        if (code !== -1) {
           atom.project.addPath(loc)
           glob(`${loc}/src/opcontrol.*`, (err, files) => {
             if(files.length > 0) {

--- a/package.json
+++ b/package.json
@@ -4,17 +4,20 @@
   "version": "0.0.2",
   "description": "A short description of your package",
   "keywords": [],
-  "activationHooks": ["core:loaded-shell-environment"],
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ],
   "repository": "https://github.com/purduesigbots/pros-atom3",
   "license": "MPL-2.0",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "atom-package-deps": "^4.6.2",
     "@purduesigbots/pros-cli-middleware": "latest",
+    "atom-package-deps": "^4.6.2",
     "etch": "^0.12.8",
     "glob": "^7.1.2",
+    "strip-ansi": "^4.0.0",
     "voucher": "^0.1.2",
     "which": "^1.3.0"
   },


### PR DESCRIPTION
### Summary

Should create the `compile_commands.json` file immediately after project creation, so cquery doesn't mistakenly tell users that their new project is full of errors

### Test Plan

- [x] project created successfully
- [x] project compiles after creation
- [x] `compile_commands.json` generated properly (no more cquery errors shown for fresh project)

#### References
T571
