### PR TITLE
Compile commands watcher

### DIFF
--- a/lib/middleware-linkage/middlewareCallbackHelper.js
+++ b/lib/middleware-linkage/middlewareCallbackHelper.js
@@ -19,9 +19,6 @@ function zCLIjs(middlewareFunction, callbacks, ...args) {
   } else {
     promise = _f()
   }
-  promise.then((code) => {
-    console.log('default all done')
-  })
   return promise;
 }
 

--- a/lib/pros-atom3.js
+++ b/lib/pros-atom3.js
@@ -5,7 +5,7 @@ import { Disposable, CompositeDisposable } from 'atom'
 
 import commands from './commands'
 import config from './config'
-import { consumeConsole, consumeBusySignal, consumeTerminalTab, provideBuilder } from './util'
+import { consumeConsole, consumeBusySignal, consumeTerminalTab, provideBuilder, projectFilesChanged } from './util'
 import { NewProjectView, UpgradeProjectView } from './views'
 
 toolbar = null
@@ -73,6 +73,7 @@ export default {
     const upgradeProjectViewProvider = UpgradeProjectView.register()
 
     this.subscriptions.add(atom.commands.add('atom-workspace', commands))
+    this.subscriptions.add(atom.project.onDidChangeFiles(projectFilesChanged))
   },
 
   deactivate() {

--- a/lib/util/Build.js
+++ b/lib/util/Build.js
@@ -8,7 +8,6 @@ import voucher from 'voucher';
 import { EventEmitter } from 'events';
 
 export function provideBuilder() {
-  console.log('hello');
   const gccErrorMatch = '(?<file>([A-Za-z]:[\\/])?[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(fatal error|error):\\s*(?<message>.+)';
   const gfortranErrorMatch = '(?<file>[^:\\n]+):(?<line>\\d+):(?<col>\\d+):[\\s\\S]+?Error: (?<message>.+)';
   const ocamlErrorMatch = '(?<file>[\\/0-9a-zA-Z\\._\\-]+)", line (?<line>\\d+), characters (?<col>\\d+)-(?<col_end>\\d+):\\n(?<message>.+)';

--- a/lib/util/compile-commands.js
+++ b/lib/util/compile-commands.js
@@ -39,7 +39,7 @@ export function projectFilesChanged(fileEvents) {
   for(const project of pros_projects) {
     if(!(project in serviceQueue)) {
       serviceQueue[project] = debounce((project) => {
-        zCLIjs(buildCompileCommands, {finalize: () => {}}, project, ['sources'], {
+        zCLIjs(buildCompileCommands, {finalize: () => {}}, project, ['all'], {
           sandbox: true,
           suppressOutput: true
         }).then(code => {

--- a/lib/util/compile-commands.js
+++ b/lib/util/compile-commands.js
@@ -12,17 +12,17 @@ const serviceQueue = {}
 export function projectFilesChanged(fileEvents) {
   const projects = new Set();
   const pros_projects = new Set();
-  for(const fileEvent of fileEvents) {
+  for (const fileEvent of fileEvents) {
     [projectPath, relPath] = atom.project.relativizePath(fileEvent.path);
-    if(projectPath == null || projects.has(projectPath)) {
+    if (projectPath === null || projects.has(projectPath)) {
       continue;
     }
     let process = false;
-    if((relPath.startsWith("src") || relPath.startsWith("include")) &&
+    if ((relPath.startsWith("src") || relPath.startsWith("include")) &&
        fileEvent.action !== 'modified') {
       process = true;
     }
-    if(relPath == "Makefile" || relPath == "common.mk") {
+    if (relPath === "Makefile" || relPath === "common.mk") {
       process = true;
     }
 
@@ -31,23 +31,25 @@ export function projectFilesChanged(fileEvents) {
     }
 
     projects.add(projectPath);
-    if(fs.existsSync(path.join(projectPath, 'project.pros'))) {
+    if (fs.existsSync(path.join(projectPath, 'project.pros'))) {
       pros_projects.add(projectPath);
     }
   }
 
-  for(const project of pros_projects) {
-    if(!(project in serviceQueue)) {
+  for (const project of pros_projects) {
+    if (!(project in serviceQueue)) {
       serviceQueue[project] = debounce((project) => {
         zCLIjs(buildCompileCommands, {finalize: () => {}}, project, ['all'], {
           sandbox: true,
           suppressOutput: true
         }).then(code => {
-          if(code == 0) {
+          if (code === 0) {
             console.debug(`Finished compile-commands for ${project}`);
+          } else {
+            console.log(`Faield compile-commands for ${project}`)
           }
         });
-      }, 500);
+      }, 1000);
     }
     serviceQueue[project](project);
   }

--- a/lib/util/compile-commands.js
+++ b/lib/util/compile-commands.js
@@ -1,0 +1,54 @@
+'use babel'
+
+import fs from 'fs';
+import path from 'path';
+import debounce from 'debounce';
+
+import { buildCompileCommands } from '@purduesigbots/pros-cli-middleware';
+import { zCLIjs, MiddlewareCallbackHelper } from '../middleware-linkage';
+
+const serviceQueue = {}
+
+export function projectFilesChanged(fileEvents) {
+  const projects = new Set();
+  const pros_projects = new Set();
+  for(const fileEvent of fileEvents) {
+    [projectPath, relPath] = atom.project.relativizePath(fileEvent.path);
+    if(projectPath == null || projects.has(projectPath)) {
+      continue;
+    }
+    let process = false;
+    if((relPath.startsWith("src") || relPath.startsWith("include")) &&
+       fileEvent.action !== 'modified') {
+      process = true;
+    }
+    if(relPath == "Makefile" || relPath == "common.mk") {
+      process = true;
+    }
+
+    if(!process) {
+      continue;
+    }
+
+    projects.add(projectPath);
+    if(fs.existsSync(path.join(projectPath, 'project.pros'))) {
+      pros_projects.add(projectPath);
+    }
+  }
+
+  for(const project of pros_projects) {
+    if(!(project in serviceQueue)) {
+      serviceQueue[project] = debounce((project) => {
+        zCLIjs(buildCompileCommands, {finalize: () => {}}, project, ['sources'], {
+          sandbox: true,
+          suppressOutput: true
+        }).then(code => {
+          if(code == 0) {
+            console.debug(`Finished compile-commands for ${project}`);
+          }
+        });
+      }, 500);
+    }
+    serviceQueue[project](project);
+  }
+}

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -2,3 +2,4 @@
 
 export * from './Services.js'
 export * from './Build'
+export * from './compile-commands'

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "@purduesigbots/pros-cli-middleware": "latest",
+    "@purduesigbots/pros-cli-middleware": "^2.0.0",
     "atom-package-deps": "^4.6.2",
+    "debounce": "^1.1.0",
     "etch": "^0.12.8",
     "glob": "^7.1.2",
     "strip-ansi": "^4.0.0",


### PR DESCRIPTION
### Summary

The compile commands watcher will invoke build-compile-commands whenever
a files is added/removed from the src/include directories or when a
Makefile is modified (for PROS projects). The goal is to maintain an
up-to-date compile-commands.json file. Eventually, I'd like to move all
of this file-watching logic into the CLI, but I'm having trouble finding
a Python package to do so.

The most interesting thing of note in this PR is that I'm needing to "debounce" when we build
the compile commands, so that quickly adding (or copying) multiple files into a project doesn't
cause build-compile-commands to be invoked twice.

Also, removed some debugging print statements

### Test Plan

- [X] Creating a project doesn't invoke this facility
- [X] Adding a file to an existing project invokes build-compile-commands (using Atom menus)
- [X] Adding a file to a newly created project invokes build-compile-commands (using Atom menus)
- [X] Adding several files doesn't invoke build-compile-commands multiple times.

#### References

T527, T572
