### PR TITLE
🐛 Fix typo

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -59,7 +59,7 @@ export default {
       const [shell, cmdOpt] = getShell()
       return createTerminalTab({
         shellPath: shell,
-        shellArgs: `${cmdopt}`,
+        shellArgs: `${cmdOpt}`,
         cwd: path.dirname(atom.workspace.getActiveTextEditor().getPath())
       })
     }


### PR DESCRIPTION
Variables are case sensitive

### Summary

- Typo

### Test Plan

- [X] Invoke `pros:build-quick` and runs without error

#### References

N/A
