### PR TITLE
🐛 Add detection for edge case in new project path detection

### DIFF
--- a/lib/components/modals/NewProjectComponent.js
+++ b/lib/components/modals/NewProjectComponent.js
@@ -40,7 +40,7 @@ export default class NewProjectComponent {
       defaultPath = activeEditor.getDirectoryPath()
       if (atom.project.rootDirectories.length) {
         for (let dir of atom.project.rootDirectories) {
-          if (dir.isPathPrefixOf(dir.realPath, activeEditor.getPath())) {
+          if (activeEditor.getPath() && dir.isPathPrefixOf(dir.realPath, activeEditor.getPath())) {
             defaultPath = path.dirname(dir.realPath)
           }
         }


### PR DESCRIPTION
### Summary
Correctly handle the case where there is an active text editor but the editor does not have an associated path (e.g. a new file buffer)

### Test Plan

- [x] open the new project dialog when the active editor has no path associated

#### References

Closes #25 
