### PR TITLE
🚸 improve error message when user not in a project

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -27,6 +27,15 @@ const getShell = () => {
   return [shell, cmdOpt]
 }
 
+const getProjectPathOrError = (action = 'build') => {
+  if (atom.workspace.getActiveTextEditor() && atom.workspace.getActiveTextEditor().getPath()) {
+    return path.dirname(atom.workspace.getActiveTextEditor().getPath())
+  } else {
+    atom.notifications.addError(`Could not determine which project to ${action}! Please open a file from a PROS project and try again.`)
+    return null
+  }
+}
+
 export default {
   'pros:new-project': {
     displayName: 'PROS: New Project',
@@ -45,10 +54,12 @@ export default {
     description: 'Build the current PROS project with the rule specified in settings',
     didDispatch: (event) => {
       const [shell, cmdOpt] = getShell()
+      const cwd = getProjectPathOrError()
+      if (!cwd) return
       return createTerminalTab({
         shellPath: shell,
         shellArgs: `${cmdOpt}${atom.config.get('pros-atom3.build.buildAction')}`,
-        cwd: path.dirname(atom.workspace.getActiveTextEditor().getPath())
+        cwd
       })
     }
   },
@@ -57,10 +68,12 @@ export default {
     description: 'Build the current PROS project with the default rule',
     didDispatch: (event) => {
       const [shell, cmdOpt] = getShell()
+      const cwd = getProjectPathOrError()
+      if (!cwd) return
       return createTerminalTab({
         shellPath: shell,
         shellArgs: `${cmdOpt}`,
-        cwd: path.dirname(atom.workspace.getActiveTextEditor().getPath())
+        cwd
       })
     }
   },
@@ -69,10 +82,12 @@ export default {
     description: 'Build the current PROS project with the \'quick\' rule',
     didDispatch: (event) => {
       const [shell, cmdOpt] = getShell()
+      const cwd = getProjectPathOrError()
+      if (!cwd) return
       return createTerminalTab({
         shellPath: shell,
         shellArgs: `${cmdOpt}quick`,
-        cwd: path.dirname(atom.workspace.getActiveTextEditor().getPath())
+        cwd
       })
     }
   },
@@ -81,10 +96,12 @@ export default {
     description: 'Clean the current PROS project (pros build clean)',
     didDispatch: (event) => {
       const [shell, cmdOpt] = getShell()
+      const cwd = getProjectPathOrError()
+      if (!cwd) return
       return createTerminalTab({
         shellPath: shell,
         shellArgs: `${cmdOpt}clean`,
-        cwd: path.dirname(atom.workspace.getActiveTextEditor().getPath())
+        cwd
       })
     }
   },
@@ -93,30 +110,37 @@ export default {
     description: 'Build the current PROS project with the \'all \' rule',
     didDispatch: (event) => {
       const [shell, cmdOpt] = getShell()
+      const cwd = getProjectPathOrError()
+      if (!cwd) return
       return createTerminalTab({
         shellPath: shell,
         shellArgs: `${cmdOpt}all`,
-        cwd: path.dirname(atom.workspace.getActiveTextEditor().getPath())
+        cwd
       })
     }
   },
   'pros:upload': {
     displayName: 'PROS: Upload Project',
     didDispatch: (event) => {
+      const cwd = getProjectPathOrError('upload')
+      if (!cwd) return
       return zCLIjs(
         uploadProject,
         {label: 'PROS Basic Upload'},
-        path.dirname(atom.workspace.getActiveTextEditor().getPath())
+        cwd
       )
     }
   },
   'pros:terminal': {
     displayName: 'PROS: Open Terminal',
     didDispatch: (event) => {
+      // TODO: something better for this? maybe reword
+      const cwd = getProjectPathOrError('use')
+      if (!cwd) return
       return createTerminalTab({
         shellPath: getzCLIExecutable(),
         shellArgs: 'terminal',
-        cwd: path.dirname(atom.workspace.getActiveTextEditor().getPath())
+        cwd
       });
     }
   },


### PR DESCRIPTION
### Summary

Explicitly notify the user that we can't determine which project they
wish to act on.

Note that determining whether a file is actually in a PROS project is handled by the CLI. As such, if a user runs a command that requires a cwd when a file is active that is not part of a PROS project results in different behavior depending on how the command is run (terminal commands show an error in the terminal, and other commands do nothing).

### Test Plan

- [x] running commands that require a cwd when a file has no path associated displays new error message

#### References

Closes #21 
