### PR TITLE
🚸 Add better notification autodismiss

### DIFF
--- a/lib/middleware-linkage/notificationManager.js
+++ b/lib/middleware-linkage/notificationManager.js
@@ -33,22 +33,22 @@ export default class NotificationManager {
     let notification = this.get(data.notify_value)
     if(typeof notification === 'undefined') {
       this.notifications[data.notify_value] = {
-        'notification': atom.notifications.addInfo(stripAnsi(data.text), {dismissable: true}),
-        'detail': null,
-        'timeout': null
+        notification: atom.notifications.addInfo(stripAnsi(data.text), {dismissable: true}),
+        detail: null,
+        timeout: null
       }
       notification = this.notifications[data.notify_value]
-      const notificationView = atom.views.getView(notification['notification']).element
-      notification['detail'] = notificationView.querySelector('.detail-content') || notificationView.querySelector('.content')
-      notification['detail'].parentNode.style.display = 'block'
+      const notificationView = atom.views.getView(notification.notification).element
+      notification.detail = notificationView.querySelector('.detail-content') || notificationView.querySelector('.content')
+      notification.detail.parentNode.style.display = 'block'
     }
     try {
-        let child = notification['detail'].lastChild
+        let child = notification.detail.lastChild
         if(data.type == 'notify/echo') {
           if(!child || child.tagName != 'DIV') {
             child = document.createElement('div')
             child.style.whiteSpace = 'pre-wrap'
-            notification['detail'].appendChild(child)
+            notification.detail.appendChild(child)
           }
           child.textContent += stripAnsi(data.text)
         }
@@ -57,12 +57,12 @@ export default class NotificationManager {
           const newValue = data.pct * 100
           if(!child || child.tagName != 'SPAN') {
             child = createNewProgress()
-            notification['detail'].appendChild(child)
+            notification.detail.appendChild(child)
           }
           const hasNewLabel = (newLabel != child.firstChild.textContent)
           if(hasNewLabel && newValue < child.lastChild.value) {
             child = createNewProgress()
-            notification['detail'].appendChild(child)
+            notification.detail.appendChild(child)
           }
           if(data.text) {
             if(hasNewLabel) {
@@ -78,12 +78,12 @@ export default class NotificationManager {
           }
           child.lastChild.value = newValue
         }
-        if(notification['timeout']) {
-          clearTimeout(notification['timeout'])
+        if(notification.timeout) {
+          clearTimeout(notification.timeout)
         }
-        notification['timeout'] = setTimeout((notification) => {
+        notification.timeout = setTimeout((notification) => {
           notification.dismiss()
-        }, 5000, notification['notification'])
+        }, 5000, notification.notification)
     } catch(e) { console.log(e) }
   }
 }

--- a/lib/middleware-linkage/notificationManager.js
+++ b/lib/middleware-linkage/notificationManager.js
@@ -33,8 +33,9 @@ export default class NotificationManager {
     let notification = this.get(data.notify_value)
     if(typeof notification === 'undefined') {
       this.notifications[data.notify_value] = {
-        'notification': atom.notifications.addInfo(stripAnsi(data.text)),
-        'detail': null
+        'notification': atom.notifications.addInfo(stripAnsi(data.text), {dismissable: true}),
+        'detail': null,
+        'timeout': null
       }
       notification = this.notifications[data.notify_value]
       const notificationView = atom.views.getView(notification['notification']).element
@@ -77,6 +78,12 @@ export default class NotificationManager {
           }
           child.lastChild.value = newValue
         }
+        if(notification['timeout']) {
+          clearTimeout(notification['timeout'])
+        }
+        notification['timeout'] = setTimeout((notification) => {
+          notification.dismiss()
+        }, 5000, notification['notification'])
     } catch(e) { console.log(e) }
   }
 }


### PR DESCRIPTION
### Summary

- Uses `setTimeout` and `clearTimeout` to provide for better, longer lasting notifications for a healthier echo experience
- Whenever a notification is updated in the notification manager, it resets the autodismiss timeout so that it doesn't disappear halfway through whatever operation was happening

### Test Plan

- [X] Upload wirelessly notification sticks around for the whole thing

#### References

N/A
